### PR TITLE
Break instance init to two steps to access wasm global on start function error

### DIFF
--- a/lib/runtime-core/src/instance.rs
+++ b/lib/runtime-core/src/instance.rs
@@ -171,7 +171,7 @@ impl Instance {
                 LocalOrImport::Import(import_func_index) => NonNull::new(
                     instance.inner.import_backing.vm_functions[import_func_index].func as *mut _,
                 )
-                    .unwrap(),
+                .unwrap(),
             };
 
             let ctx_ptr = match start_index.local_or_import(&instance.module.info) {

--- a/lib/runtime-core/src/instance.rs
+++ b/lib/runtime-core/src/instance.rs
@@ -118,32 +118,32 @@ impl Instance {
         // We need to push the code version so that the exception table can be read
         // in the feault handler so that we can report traps correctly
         #[cfg(unix)]
-            {
-                let push_code_version_logic = || {
-                    if let Some(msm) = module.runnable_module.get_module_state_map() {
-                        push_code_version(CodeVersion {
-                            baseline: true,
-                            msm,
-                            base: module.runnable_module.get_code()?.as_ptr() as usize,
-                            // convert from a `String` to a static string;
-                            // can't use `Backend` directly because it's defined in `runtime`.
-                            // This is a hack and we need to clean it up.
-                            backend: match module.info.backend.as_ref() {
-                                "llvm" => "llvm",
-                                "cranelift" => "cranelift",
-                                "singlepass" => "singlepass",
-                                "auto" => "auto",
-                                _ => "unknown backend",
-                            },
-                            runnable_module: module.runnable_module.clone(),
-                        });
-                        Some(())
-                    } else {
-                        None
-                    }
-                };
-                inner.code_version_pushed = push_code_version_logic().is_some();
-            }
+        {
+            let push_code_version_logic = || {
+                if let Some(msm) = module.runnable_module.get_module_state_map() {
+                    push_code_version(CodeVersion {
+                        baseline: true,
+                        msm,
+                        base: module.runnable_module.get_code()?.as_ptr() as usize,
+                        // convert from a `String` to a static string;
+                        // can't use `Backend` directly because it's defined in `runtime`.
+                        // This is a hack and we need to clean it up.
+                        backend: match module.info.backend.as_ref() {
+                            "llvm" => "llvm",
+                            "cranelift" => "cranelift",
+                            "singlepass" => "singlepass",
+                            "auto" => "auto",
+                            _ => "unknown backend",
+                        },
+                        runnable_module: module.runnable_module.clone(),
+                    });
+                    Some(())
+                } else {
+                    None
+                }
+            };
+            inner.code_version_pushed = push_code_version_logic().is_some();
+        }
 
         let instance = Instance {
             module,

--- a/lib/runtime-core/src/instance.rs
+++ b/lib/runtime-core/src/instance.rs
@@ -155,7 +155,8 @@ impl Instance {
         Ok(instance)
     }
 
-    pub fn call_start_func(self) -> Result<Instance> {
+    /// Call the start function of the module, if any
+    pub fn call_start_func(&self) -> Result<()> {
         let instance = self;
         if let Some(start_index) = instance.module.info.start_func {
             // We know that the start function takes no arguments and returns no values.
@@ -202,12 +203,13 @@ impl Instance {
             start_func.call()?;
         }
 
-        Ok(instance)
+        Ok(())
     }
 
     pub(crate) fn new(module: Arc<ModuleInner>, imports: &ImportObject) -> Result<Instance> {
         let instance = Instance::new_without_start_func(module, imports)?;
-        instance.call_start_func()
+        instance.call_start_func()?;
+        Ok(instance)
     }
 
     /// Load an `Instance` using the given loader.

--- a/lib/runtime-core/src/module.rs
+++ b/lib/runtime-core/src/module.rs
@@ -196,6 +196,12 @@ impl Module {
         Instance::new(Arc::clone(&self.inner), import_object)
     }
 
+    /// Instantiate a WebAssembly module with the provided [`ImportObject`].
+    /// Do not call the `start` function in the WebAssembly module.
+    pub fn instantiate_without_start_func(&self, import_object: &ImportObject) -> error::Result<Instance> {
+        Instance::new_without_start_func(Arc::clone(&self.inner), import_object)
+    }
+
     /// Create a cache artifact from this module.
     pub fn cache(&self) -> Result<Artifact, CacheError> {
         let (backend_metadata, code) = self.inner.cache_gen.generate_cache()?;


### PR DESCRIPTION
break instance init to create instance step and call start function step. This is because if start function went into error, we don't have an instance in near, therefore cannot access the gas counter global in near.
