### PR TITLE
Provide available ops to gas counter at instance initialization

### DIFF
--- a/lib/api/src/sys/module.rs
+++ b/lib/api/src/sys/module.rs
@@ -286,6 +286,25 @@ impl Module {
         }
     }
 
+    pub(crate) fn instantiate_with_remaining_ops(
+        &self,
+        resolver: &dyn Resolver,
+        remaining_ops: u64
+    ) -> Result<InstanceHandle, InstantiationError> {
+        unsafe {
+            let instance_handle = self.artifact.instantiate(
+                self.store.tunables(),
+                resolver,
+                Box::new((self.store.clone(), self.artifact.clone())),
+            )?;
+
+            self.artifact
+                .finish_instantiate_with_remaining_ops(&self.store, &instance_handle, remaining_ops)?;
+
+            Ok(instance_handle)
+        }
+    }
+
     /// Returns the name of the current module.
     ///
     /// This name is normally set in the WebAssembly bytecode by some


### PR DESCRIPTION
I also attempted the proposal by @olonho: provide available ops to gas counter at instance initialization. But it seems not work. 
Because we also need the instance object, when initialization is success, but call start_func failing. We need the instance object in order to retrieve gas spent in start_func. But initialization function will return the error if start_func failing. So we need the two step initialization :(