### PR TITLE
Cold start repro and optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +281,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "winapi",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,7 +309,7 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim 0.8.0",
@@ -1311,6 +1332,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,7 +1545,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "ctor",
  "difference",
  "output_vt100",
@@ -2237,18 +2268,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-span-tree"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877726b1570d7764022ef20cc61479b5bcfc1118b90521ce61f6cc9e4f5ffbd8"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62af966210b88ad5776ee3ba12d5f35b8d6a2b2a12168f3080cf02b814d7376b"
 dependencies = [
+ "ansi_term 0.12.1",
+ "chrono",
  "lazy_static",
  "matchers",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2764,6 +2833,8 @@ dependencies = [
  "serde_bytes",
  "target-lexicon 0.12.2",
  "thiserror",
+ "tracing",
+ "tracing-span-tree",
  "wasmer-compiler-near",
  "wasmer-types-near",
  "wasmer-vm-near",
@@ -2797,6 +2868,8 @@ dependencies = [
  "loupe",
  "region",
  "rkyv",
+ "tracing",
+ "tracing-span-tree",
  "wasmer-compiler-near",
  "wasmer-engine-near",
  "wasmer-types-near",
@@ -2840,6 +2913,8 @@ dependencies = [
  "target-lexicon 0.12.2",
  "tempfile",
  "thiserror",
+ "tracing",
+ "tracing-span-tree",
  "wasm-bindgen",
  "wasm-bindgen-test",
  "wasmer-compiler-cranelift",
@@ -2906,6 +2981,8 @@ dependencies = [
  "rkyv",
  "serde",
  "thiserror",
+ "tracing",
+ "tracing-span-tree",
  "wasmer-types-near",
  "winapi",
 ]
@@ -2986,6 +3063,7 @@ dependencies = [
  "test-env-log",
  "test-generator",
  "tracing",
+ "tracing-span-tree",
  "tracing-subscriber",
  "wasi-test-generator",
  "wasmer-cache",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ loupe = "0.1"
 test-env-log = { version = "0.2", default-features = false, features = ["trace"] }
 tracing = { version = "0.1", default-features = false, features = ["log"] }
 tracing-subscriber = { version = "0.2", default-features = false, features = ["env-filter", "fmt"] }
+tracing-span-tree = "0.1"
 
 [features]
 # Don't add the compiler features in default, please add them on the Makefile

--- a/examples/compiler_singlepass.rs
+++ b/examples/compiler_singlepass.rs
@@ -63,6 +63,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let _span = tracing::debug_span!(target: "vm", "Instance::new").entered();
         Instance::new(&module, &import_object)?
     };
+
+    println!("Instantiating module... the second time");
+    let instance = {
+        // This one matches NEAR's execution model of initialization
+        let _span = tracing::debug_span!(target: "vm", "Instance::new").entered();
+        Instance::new(&module, &import_object)?
+    };
     let main = instance.exports.get_function("main")?;
 
     println!("Calling `main` function...");

--- a/examples/compiler_singlepass.rs
+++ b/examples/compiler_singlepass.rs
@@ -10,24 +10,39 @@
 //!
 //! Ready?
 
+use std::fmt::Write;
 use wasmer::{imports, wat2wasm, Instance, Module, Store, Value};
 use wasmer_compiler_singlepass::Singlepass;
 use wasmer_engine_universal::Universal;
 
+pub fn many_functions_contract(function_count: u32) -> Vec<u8> {
+    let mut functions = String::new();
+    for i in 0..function_count {
+        writeln!(
+            &mut functions,
+            "(func
+              i32.const {}
+              drop
+              return)",
+            i
+        )
+        .unwrap();
+    }
+
+    let code = format!(
+        r#"(module
+          (export "main" (func 0))
+          {})"#,
+        functions
+    );
+    wat2wasm(code.as_bytes()).unwrap().to_vec()
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_span_tree::span_tree().enable();
+
     // Let's declare the Wasm module with the text representation.
-    let wasm_bytes = wat2wasm(
-        r#"
-(module
-  (type $sum_t (func (param i32 i32) (result i32)))
-  (func $sum_f (type $sum_t) (param $x i32) (param $y i32) (result i32)
-    local.get $x
-    local.get $y
-    i32.add)
-  (export "sum" (func $sum_f)))
-"#
-        .as_bytes(),
-    )?;
+    let wasm_bytes = many_functions_contract(150_000);
 
     // Use Singlepass compiler with the default settings
     let compiler = Singlepass::default();
@@ -43,18 +58,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let import_object = imports! {};
 
     println!("Instantiating module...");
-    // Let's instantiate the Wasm module.
-    let instance = Instance::new(&module, &import_object)?;
+    let instance = {
+        // Let's instantiate the Wasm module.
+        let _span = tracing::debug_span!(target: "vm", "Instance::new").entered();
+        Instance::new(&module, &import_object)?
+    };
+    let main = instance.exports.get_function("main")?;
 
-    let sum = instance.exports.get_function("sum")?;
-
-    println!("Calling `sum` function...");
-    // Let's call the `sum` exported function. The parameters are a
-    // slice of `Value`s. The results are a boxed slice of `Value`s.
-    let results = sum.call(&[Value::I32(1), Value::I32(2)])?;
+    println!("Calling `main` function...");
+    let results = main.call(&[])?;
 
     println!("Results: {:?}", results);
-    assert_eq!(results.to_vec(), vec![Value::I32(3)]);
+    // assert_eq!(results.to_vec(), vec![Value::I32(3)]);
 
     Ok(())
 }

--- a/examples/compiler_singlepass.rs
+++ b/examples/compiler_singlepass.rs
@@ -39,7 +39,7 @@ pub fn many_functions_contract(function_count: u32) -> Vec<u8> {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_span_tree::span_tree().enable();
+    tracing_span_tree::span_tree().aggregate(true).enable();
 
     // Let's declare the Wasm module with the text representation.
     let wasm_bytes = many_functions_contract(150_000);

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -26,6 +26,8 @@ indexmap = { version = "1.6", features = ["serde-1"] }
 cfg-if = "1.0"
 thiserror = "1.0"
 more-asserts = "0.2"
+tracing = { version = "0.1", default-features = false, features = ["log"] }
+tracing-span-tree = "0.1"
 # - Optional shared dependencies.
 wat = { version = "1.0", optional = true }
 

--- a/lib/api/src/sys/module.rs
+++ b/lib/api/src/sys/module.rs
@@ -268,20 +268,27 @@ impl Module {
         resolver: &dyn Resolver,
     ) -> Result<InstanceHandle, InstantiationError> {
         unsafe {
-            let instance_handle = self.artifact.instantiate(
-                self.store.tunables(),
-                resolver,
-                Box::new((self.store.clone(), self.artifact.clone())),
-            )?;
+            let instance_handle = {
+                let _span = tracing::debug_span!(target: "vm", "artifact.instantiate").entered();
+                self.artifact.instantiate(
+                    self.store.tunables(),
+                    resolver,
+                    Box::new((self.store.clone(), self.artifact.clone())),
+                )?
+            };
 
             // After the instance handle is created, we need to initialize
             // the data, call the start function and so. However, if any
             // of this steps traps, we still need to keep the instance alive
             // as some of the Instance elements may have placed in other
             // instance tables.
-            self.artifact
-                .finish_instantiation(&self.store, &instance_handle)?;
 
+            {
+                let _span =
+                    tracing::debug_span!(target: "vm", "artifact.finish_instantiation").entered();
+                self.artifact
+                    .finish_instantiation(&self.store, &instance_handle)?;
+            }
             Ok(instance_handle)
         }
     }

--- a/lib/c-api/wasmer.h
+++ b/lib/c-api/wasmer.h
@@ -62,14 +62,23 @@
 #  define DEPRECATED(message) __declspec(deprecated(message))
 #endif
 
+// The `universal` feature has been enabled for this build.
+#define WASMER_UNIVERSAL_ENABLED
+
+// The `compiler` feature has been enabled for this build.
+#define WASMER_COMPILER_ENABLED
+
 // The `wasi` feature has been enabled for this build.
 #define WASMER_WASI_ENABLED
 
+// The `middlewares` feature has been enabled for this build.
+#define WASMER_MIDDLEWARES_ENABLED
+
 // This file corresponds to the following Wasmer version.
-#define WASMER_VERSION "2.0.0"
+#define WASMER_VERSION "2.0.1"
 #define WASMER_VERSION_MAJOR 2
 #define WASMER_VERSION_MINOR 0
-#define WASMER_VERSION_PATCH 0
+#define WASMER_VERSION_PATCH 1
 #define WASMER_VERSION_PRE ""
 
 #endif // WASMER_H_PRELUDE

--- a/lib/engine-universal/Cargo.toml
+++ b/lib/engine-universal/Cargo.toml
@@ -21,6 +21,8 @@ cfg-if = "1.0"
 leb128 = "0.2"
 rkyv = "0.6.1"
 loupe = "0.1"
+tracing = { version = "0.1", default-features = false, features = ["log"] }
+tracing-span-tree = "0.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["winnt", "impl-default"] }

--- a/lib/engine/Cargo.toml
+++ b/lib/engine/Cargo.toml
@@ -25,6 +25,8 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_bytes = { version = "0.11" }
 lazy_static = "1.4"
 loupe = "0.1"
+tracing = { version = "0.1", default-features = false, features = ["log"] }
+tracing-span-tree = "0.1"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -23,6 +23,8 @@ backtrace = "0.3"
 serde = { version = "1.0", features = ["derive", "rc"] }
 rkyv = { version = "0.6.1", optional = true}
 loupe = { version = "0.1", features = ["enable-indexmap"] }
+tracing = { version = "0.1", default-features = false, features = ["log"] }
+tracing-span-tree = "0.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["winbase", "memoryapi", "errhandlingapi"] }

--- a/lib/vm/src/func_data_registry.rs
+++ b/lib/vm/src/func_data_registry.rs
@@ -90,7 +90,7 @@ unsafe impl Sync for VMFuncRef {}
 #[derive(Debug, Default, MemoryUsage)]
 struct Inner {
     func_data: Vec<Box<VMCallerCheckedAnyfunc>>,
-    anyfunc_to_index: HashMap<VMCallerCheckedAnyfunc, usize>,
+    // anyfunc_to_index: HashMap<VMCallerCheckedAnyfunc, usize>,
 }
 
 impl FuncDataRegistry {
@@ -104,18 +104,18 @@ impl FuncDataRegistry {
     /// Register a signature and return its unique index.
     pub fn register(&self, anyfunc: VMCallerCheckedAnyfunc) -> VMFuncRef {
         let mut inner = self.inner.lock().unwrap();
-        if let Some(&idx) = inner.anyfunc_to_index.get(&anyfunc) {
-            let data: &Box<_> = &inner.func_data[idx];
-            let inner_ptr: &VMCallerCheckedAnyfunc = &*data;
-            VMFuncRef(inner_ptr)
-        } else {
-            let idx = inner.func_data.len();
-            inner.func_data.push(Box::new(anyfunc.clone()));
-            inner.anyfunc_to_index.insert(anyfunc, idx);
+        // if let Some(&idx) = inner.anyfunc_to_index.get(&anyfunc) {
+        //     let data: &Box<_> = &inner.func_data[idx];
+        //     let inner_ptr: &VMCallerCheckedAnyfunc = &*data;
+        //     VMFuncRef(inner_ptr)
+        // } else {
+        let idx = inner.func_data.len();
+        inner.func_data.push(Box::new(anyfunc.clone()));
+        // inner.anyfunc_to_index.insert(anyfunc, idx);
 
-            let data: &Box<_> = &inner.func_data[idx];
-            let inner_ptr: &VMCallerCheckedAnyfunc = &*data;
-            VMFuncRef(inner_ptr)
-        }
+        let data: &Box<_> = &inner.func_data[idx];
+        let inner_ptr: &VMCallerCheckedAnyfunc = &*data;
+        VMFuncRef(inner_ptr)
+        // }
     }
 }

--- a/lib/vm/src/instance/mod.rs
+++ b/lib/vm/src/instance/mod.rs
@@ -1494,7 +1494,7 @@ fn build_funcrefs(
             let _span = tracing::debug_span!(target: "vm", "finished_functions.iter").entered();
             finished_functions.iter()
         } {
-            let _span = tracing::debug_span!(target: "vm", "local func").entered();
+            // let _span = tracing::debug_span!(target: "vm", "local func").entered();
             let index = {
                 // let _span = tracing::debug_span!(target: "vm", "index").entered();
                 module_info.func_index(local_index)


### PR DESCRIPTION
@Longarithm found a [many function contracts](https://github.com/near/nearcore/compare/90e182b6..8814b7c0f) which compile and execute pretty slow. This PR attempt to address the **execute** part only.

@Longarithm's result:
```
contract size = 1456KiB
vm_kind = Wasmer0
time to run no-op fn = 2.970571573s
time to run no-op fn = 640.596788ms
time to run no-op fn = 636.828433ms
time to run no-op fn = 634.383194ms
time to run no-op fn = 634.292482ms
vm_kind = Wasmer2
time to run no-op fn = 6.357417752s
time to run no-op fn = 186.123842ms
time to run no-op fn = 185.622875ms
time to run no-op fn = 190.486191ms
time to run no-op fn = 187.222724ms
```

Note the first time of wasmer0/wasmer2 including compilation + execution, and subsequent calls including execution only.

My local is about 4x faster, which I'm using as a baseline (46ms for wasmer 2 init, correspond to above 187ms). And in this PR, I move the bench in wasmer repo and it can be run to check bottlenecks and the degree of optimization. It can be run by:
```
cargo run --release --package wasmer-workspace --example compiler-singlepass --features singlepass
```

After current version of this PR, it reduce initialization time from 46ms to 14ms. Further optimization maybe possible, I'll update the number as i progress. The PR is in draft because of tracing debug prints and one error checking TODO