### PR TITLE
Build function import map once.

### DIFF
--- a/lib/compiler-singlepass/src/compiler.rs
+++ b/lib/compiler-singlepass/src/compiler.rs
@@ -59,7 +59,7 @@ impl Compiler for SinglepassCompiler {
         &self,
         target: &Target,
         compile_info: &CompileModuleInfo,
-        _module_translation: &ModuleTranslationState,
+        module_translation: &ModuleTranslationState,
         function_body_inputs: PrimaryMap<LocalFunctionIndex, FunctionBodyData<'_>>,
     ) -> Result<Compilation, CompileError> {
         if target.triple().operating_system == OperatingSystem::Windows {
@@ -109,9 +109,16 @@ impl Compiler for SinglepassCompiler {
                     }
                 }
 
-                let mut generator =
-                    FuncGen::new(module, &self.config, &vmoffsets, &table_styles, i, &locals)
-                        .map_err(to_compile_error)?;
+                let mut generator = FuncGen::new(
+                    module,
+                    module_translation,
+                    &self.config,
+                    &vmoffsets,
+                    &table_styles,
+                    i,
+                    &locals,
+                )
+                .map_err(to_compile_error)?;
 
                 while generator.has_control_frames() {
                     generator.set_srcloc(reader.original_position() as u32);

--- a/lib/compiler/src/translator/module.rs
+++ b/lib/compiler/src/translator/module.rs
@@ -102,5 +102,7 @@ pub fn translate_module<'data>(
         }
     }
 
+    module_translation_state.build_import_map(&environ.module);
+
     Ok(module_translation_state)
 }


### PR DESCRIPTION
To avoid potential issues with recomputing import map multiple times build it once after module is translated and reuse in all compilations.