### PR TITLE
Improve resilience of the gas computation codegen

### DIFF
--- a/lib/compiler-singlepass/src/emitter_x64.rs
+++ b/lib/compiler-singlepass/src/emitter_x64.rs
@@ -101,6 +101,7 @@ pub trait Emitter {
     fn emit_neg(&mut self, sz: Size, value: Location);
     fn emit_imul(&mut self, sz: Size, src: Location, dst: Location);
     fn emit_imul_imm32_gpr64(&mut self, src: u32, dst: GPR);
+    fn emit_mul(&mut self, sz: Size, src: Location);
     fn emit_div(&mut self, sz: Size, divisor: Location);
     fn emit_idiv(&mut self, sz: Size, divisor: Location);
     fn emit_shl(&mut self, sz: Size, src: Location, dst: Location);
@@ -956,6 +957,11 @@ impl Emitter for Assembler {
             binop_mem_gpr!(imul, self, sz, src, dst, {
                 panic!("singlepass can't emit IMUL {:?} {:?} {:?}", sz, src, dst)
             })
+        });
+    }
+    fn emit_mul(&mut self, sz: Size, mul: Location) {
+        unop_gpr_or_mem!(mul, self, sz, mul, {
+            panic!("singlepass can't emit MUL {:?} {:?}", sz, mul)
         });
     }
     fn emit_imul_imm32_gpr64(&mut self, src: u32, dst: GPR) {

--- a/lib/compiler-singlepass/src/machine.rs
+++ b/lib/compiler-singlepass/src/machine.rs
@@ -97,6 +97,16 @@ impl Machine {
         gpr
     }
 
+    /// Obtain ownership of the specified GPR if not already in use.
+    pub fn acquire_unused_gpr(&mut self, gpr: GPR) -> Option<GPR> {
+        if !self.used_gprs.contains(&gpr) {
+            self.used_gprs.insert(gpr);
+            Some(gpr)
+        } else {
+            None
+        }
+    }
+
     /// Picks an unused XMM register.
     ///
     /// This method does not mark the register as used.

--- a/tests/compilers/fast_gas_metering.rs
+++ b/tests/compilers/fast_gas_metering.rs
@@ -257,5 +257,5 @@ fn test_gas_intrinsic_large_opcode_cost() {
         .expect("expected function zoo");
     dbg!(gas_counter.burnt());
     let _e = peach.call(&[]).err().expect("error calling function");
-    assert_eq!(gas_counter.burnt(), 0x100_0000_0000);
+    assert_eq!(gas_counter.burnt(), 0x1_0000_0000_0000);
 }


### PR DESCRIPTION
The codegen should now be resilient to overflows and be able to operate with operation costs that exceed 32-bit range.

```asm
0:
mov    $0x100,%r12
mov    %r12,%rsi
mov    0x128(%r15,%riz,1),%rcx
mov    %rsi,%rax
mulq   0x10(%rcx,%riz,1)
jo     .integer_overflow
add    0x0(%rcx,%riz,1),%rax
jo     .integer_overflow
cmp    %rax,0x8(%rcx,%riz,1)
mov    %rax,0x0(%rcx,%riz,1)
jbe    .gas_limit_exceeded
jmp    0b
```

is what the assembly looks like for the newly added test. 