### PR TITLE
Bump to 2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,7 +2656,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-near"
-version = "2.0.3"
+version = "2.1.0"
 dependencies = [
  "enumset",
  "hashbrown 0.11.2",
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass-near"
-version = "2.0.3"
+version = "2.1.0"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive-near"
-version = "2.0.3"
+version = "2.1.0"
 dependencies = [
  "compiletest_rs",
  "proc-macro-error",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-near"
-version = "2.0.3"
+version = "2.1.0"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -2791,7 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-engine-universal-near"
-version = "2.0.3"
+version = "2.1.0"
 dependencies = [
  "cfg-if 1.0.0",
  "leb128",
@@ -2829,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-near"
-version = "2.0.3"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -2870,7 +2870,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types-near"
-version = "2.0.3"
+version = "2.1.0"
 dependencies = [
  "indexmap",
  "loupe",
@@ -2893,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm-near"
-version = "2.0.3"
+version = "2.1.0"
 dependencies = [
  "backtrace",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,21 +10,21 @@ publish = false
 autoexamples = false
 
 [dependencies]
-wasmer = { version = "2.0.0", path = "lib/api", default-features = false, package = "wasmer-near" }
-wasmer-compiler = { version = "2.0.0", path = "lib/compiler", package = "wasmer-compiler-near" }
+wasmer = { version = "=2.1.0", path = "lib/api", default-features = false, package = "wasmer-near" }
+wasmer-compiler = { version = "=2.1.0", path = "lib/compiler", package = "wasmer-compiler-near" }
 wasmer-compiler-cranelift = { version = "2.0.0", path = "lib/compiler-cranelift", optional = true }
-wasmer-compiler-singlepass = { version = "2.0.0", path = "lib/compiler-singlepass", optional = true, package = "wasmer-compiler-singlepass-near" }
+wasmer-compiler-singlepass = { version = "=2.1.0", path = "lib/compiler-singlepass", optional = true, package = "wasmer-compiler-singlepass-near" }
 wasmer-compiler-llvm = { version = "2.0.0", path = "lib/compiler-llvm", optional = true }
 wasmer-emscripten = { version = "2.0.0", path = "lib/emscripten", optional = true }
-wasmer-engine = { version = "2.0.0", path = "lib/engine", package = "wasmer-engine-near"  }
-wasmer-engine-universal = { version = "2.0.0", path = "lib/engine-universal", optional = true, package = "wasmer-engine-universal-near" }
+wasmer-engine = { version = "=2.1.0", path = "lib/engine", package = "wasmer-engine-near"  }
+wasmer-engine-universal = { version = "=2.1.0", path = "lib/engine-universal", optional = true, package = "wasmer-engine-universal-near" }
 wasmer-engine-dylib = { version = "2.0.0", path = "lib/engine-dylib", optional = true }
 wasmer-engine-staticlib = { version = "2.0.0", path = "lib/engine-staticlib", optional = true }
 wasmer-wasi = { version = "2.0.0", path = "lib/wasi", optional = true }
 wasmer-wast = { version = "2.0.0", path = "tests/lib/wast", optional = true }
 wasi-test-generator = { version = "2.0.0", path = "tests/wasi-wast", optional = true }
 wasmer-cache = { version = "2.0.0", path = "lib/cache", optional = true }
-wasmer-types = { version = "2.0.0", path = "lib/types", package = "wasmer-types-near" }
+wasmer-types = { version = "=2.1.0", path = "lib/types", package = "wasmer-types-near" }
 wasmer-middlewares = { version = "2.0.0", path = "lib/middlewares", optional = true }
 cfg-if = "1.0"
 

--- a/lib/api/Cargo.toml
+++ b/lib/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-near"
-version = "2.0.3"
+version = "2.1.0"
 description = "High-performance WebAssembly runtime"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "runtime", "vm"]
@@ -35,18 +35,18 @@ wat = { version = "1.0", optional = true }
 # Dependencies and Development Dependencies for `sys`.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # - Mandatory dependencies for `sys`.
-wasmer-vm = { path = "../vm", version = "2.0.3", package = "wasmer-vm-near" }
-wasmer-compiler = { path = "../compiler", version = "2.0.3", package = "wasmer-compiler-near" }
-wasmer-derive = { path = "../derive", version = "2.0.3", package = "wasmer-derive-near" }
-wasmer-engine = { path = "../engine", version = "2.0.3", package = "wasmer-engine-near" }
-wasmer-types = { path = "../types", version = "2.0.3", package = "wasmer-types-near" }
+wasmer-vm = { path = "../vm", version = "=2.1.0", package = "wasmer-vm-near" }
+wasmer-compiler = { path = "../compiler", version = "=2.1.0", package = "wasmer-compiler-near" }
+wasmer-derive = { path = "../derive", version = "=2.1.0", package = "wasmer-derive-near" }
+wasmer-engine = { path = "../engine", version = "=2.1.0", package = "wasmer-engine-near" }
+wasmer-types = { path = "../types", version = "=2.1.0", package = "wasmer-types-near" }
 target-lexicon = { version = "0.12.2", default-features = false }
 loupe = "0.1"
 # - Optional dependencies for `sys`.
-wasmer-compiler-singlepass = { path = "../compiler-singlepass", package = "wasmer-compiler-singlepass-near", version = "2.0.3", optional = true}
+wasmer-compiler-singlepass = { path = "../compiler-singlepass", package = "wasmer-compiler-singlepass-near", version = "=2.1.0", optional = true}
 wasmer-compiler-cranelift = { path = "../compiler-cranelift", version = "2.0.0", optional = true }
 wasmer-compiler-llvm = { path = "../compiler-llvm", version = "2.0.0", optional = true }
-wasmer-engine-universal = { path = "../engine-universal", package = "wasmer-engine-universal-near", version = "2.0.3", optional = true }
+wasmer-engine-universal = { path = "../engine-universal", package = "wasmer-engine-universal-near", version = "=2.1.0", optional = true }
 wasmer-engine-dylib = { path = "../engine-dylib", version = "2.0.0", optional = true }
 # - Mandatory dependencies for `sys` on Windows.
 [target.'cfg(all(not(target_arch = "wasm32"), target_os = "windows"))'.dependencies]
@@ -60,10 +60,10 @@ anyhow = "1.0"
 # Dependencies and Develoment Dependencies for `js`.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # - Mandatory dependencies for `js`.
-wasmer-types = { path = "../types", version = "2.0.3", package = "wasmer-types-near", default-features = false, features = ["std"] }
+wasmer-types = { path = "../types", version = "=2.1.0", package = "wasmer-types-near", default-features = false, features = ["std"] }
 wasm-bindgen = "0.2.74"
 js-sys = "0.3.51"
-wasmer-derive = { path = "../derive", version = "2.0.3", package = "wasmer-derive-near" }
+wasmer-derive = { path = "../derive", version = "=2.1.0", package = "wasmer-derive-near" }
 # - Optional dependencies for `js`.
 wasmparser = { version = "0.78", default-features = false, optional = true }
 hashbrown = { version = "0.11", optional = true }

--- a/lib/compiler-singlepass/Cargo.toml
+++ b/lib/compiler-singlepass/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-compiler-singlepass-near"
-version = "2.0.3"
+version = "2.1.0"
 description = "Singlepass compiler for Wasmer WebAssembly runtime"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "compiler", "singlepass"]
@@ -15,9 +15,9 @@ edition = "2018"
 name = "wasmer_compiler_singlepass"
 
 [dependencies]
-wasmer-compiler = { path = "../compiler", package = "wasmer-compiler-near", version = "2.0.3", features = ["translator"], default-features = false }
-wasmer-vm = { path = "../vm", package = "wasmer-vm-near", version = "2.0.3", features = ["avoid-tls-signals"] }
-wasmer-types = { path = "../types", package = "wasmer-types-near", version = "2.0.3", default-features = false, features = ["std"] }
+wasmer-compiler = { path = "../compiler", package = "wasmer-compiler-near", version = "=2.1.0", features = ["translator"], default-features = false }
+wasmer-vm = { path = "../vm", package = "wasmer-vm-near", version = "=2.1.0", features = ["avoid-tls-signals"] }
+wasmer-types = { path = "../types", package = "wasmer-types-near", version = "=2.1.0", default-features = false, features = ["std"] }
 rayon = { version = "1.5", optional = true }
 hashbrown = { version = "0.11", optional = true }
 more-asserts = "0.2"

--- a/lib/compiler/Cargo.toml
+++ b/lib/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-compiler-near"
-version = "2.0.3"
+version = "2.1.0"
 description = "Base compiler abstraction for Wasmer WebAssembly runtime"
 categories = ["wasm", "no-std"]
 keywords = ["wasm", "webassembly", "compiler"]
@@ -11,8 +11,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-wasmer-vm = { path = "../vm", package = "wasmer-vm-near", version = "2.0.3" }
-wasmer-types = { path = "../types", package = "wasmer-types-near", version = "2.0.3", default-features = false }
+wasmer-vm = { path = "../vm", package = "wasmer-vm-near", version = "=2.1.0" }
+wasmer-types = { path = "../types", package = "wasmer-types-near", version = "=2.1.0", default-features = false }
 wasmparser = { version = "0.78", optional = true, default-features = false }
 target-lexicon = { version = "0.12.2", default-features = false }
 enumset = "1.0"

--- a/lib/derive/Cargo.toml
+++ b/lib/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-derive-near"
-version = "2.0.3"
+version = "2.1.0"
 description = "Wasmer derive macros"
 authors = ["Wasmer Engineering Team <engineering@wasmer.io>"]
 repository = "https://github.com/wasmerio/wasmer"
@@ -17,5 +17,5 @@ proc-macro2 = "1"
 proc-macro-error = "1.0.0"
 
 [dev-dependencies]
-wasmer = { path = "../api", version = "2.0.3", package = "wasmer-near" }
+wasmer = { path = "../api", version = "=2.1.0", package = "wasmer-near" }
 compiletest_rs = "0.6"

--- a/lib/engine-universal/Cargo.toml
+++ b/lib/engine-universal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-engine-universal-near"
-version = "2.0.3"
+version = "2.1.0"
 description = "Wasmer Universal Engine"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "engine", "universal"]
@@ -14,10 +14,10 @@ edition = "2018"
 name = "wasmer_engine_universal"
 
 [dependencies]
-wasmer-types = { path = "../types", version = "2.0.3", package = "wasmer-types-near", features = ["enable-rkyv"] }
-wasmer-compiler = { path = "../compiler", version = "2.0.3", package = "wasmer-compiler-near", features = ["translator", "enable-rkyv"] }
-wasmer-vm = { path = "../vm", version = "2.0.3", package = "wasmer-vm-near", features = ["enable-rkyv"] }
-wasmer-engine = { path = "../engine", package = "wasmer-engine-near", version = "2.0.3" }
+wasmer-types = { path = "../types", version = "=2.1.0", package = "wasmer-types-near", features = ["enable-rkyv"] }
+wasmer-compiler = { path = "../compiler", version = "=2.1.0", package = "wasmer-compiler-near", features = ["translator", "enable-rkyv"] }
+wasmer-vm = { path = "../vm", version = "=2.1.0", package = "wasmer-vm-near", features = ["enable-rkyv"] }
+wasmer-engine = { path = "../engine", package = "wasmer-engine-near", version = "=2.1.0" }
 # flexbuffers = { path = "../../../flatbuffers/rust/flexbuffers", version = "0.1.0" }
 region = "3.0"
 cfg-if = "1.0"

--- a/lib/engine/Cargo.toml
+++ b/lib/engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-engine-near"
-version = "2.0.3"
+version = "2.1.0"
 description = "Wasmer Engine abstraction"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly", "engine"]
@@ -14,9 +14,9 @@ edition = "2018"
 name = "wasmer_engine"
 
 [dependencies]
-wasmer-types = { path = "../types", version = "2.0.3", package = "wasmer-types-near" }
-wasmer-compiler = { path = "../compiler", version = "2.0.3", package = "wasmer-compiler-near" }
-wasmer-vm = { path = "../vm", version = "2.0.3", package = "wasmer-vm-near" }
+wasmer-types = { path = "../types", version = "=2.1.0", package = "wasmer-types-near" }
+wasmer-compiler = { path = "../compiler", version = "=2.1.0", package = "wasmer-compiler-near" }
+wasmer-vm = { path = "../vm", version = "=2.1.0", package = "wasmer-vm-near" }
 target-lexicon = { version = "0.12.2", default-features = false }
 # flexbuffers = { path = "../../../flatbuffers/rust/flexbuffers", version = "0.1.0" }
 backtrace = "0.3"

--- a/lib/types/Cargo.toml
+++ b/lib/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-types-near"
-version = "2.0.3"
+version = "2.1.0"
 description = "Wasmer Common Types"
 categories = ["wasm", "no-std", "data-structures"]
 keywords = ["wasm", "webassembly", "types"]

--- a/lib/vm/Cargo.toml
+++ b/lib/vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-vm-near"
-version = "2.0.3"
+version = "2.1.0"
 description = "Runtime library support for Wasmer"
 categories = ["wasm"]
 keywords = ["wasm", "webassembly"]
@@ -14,7 +14,7 @@ edition = "2018"
 name = "wasmer_vm"
 
 [dependencies]
-wasmer-types = { path = "../types", package = "wasmer-types-near", version = "2.0.3" }
+wasmer-types = { path = "../types", package = "wasmer-types-near", version = "=2.1.0" }
 region = "3.0"
 libc = { version = "^0.2", default-features = false }
 memoffset = "0.6"


### PR DESCRIPTION
There are a couple other changes than just a bump – in particular we lock all transitive dependencies using `=` to ensure that downstream depending on `wasmer-near 2.1.0` doesn't start pulling in `wasmer-types-near 2.2.0` or something.