### PR TITLE
Responsibility to check CPU features is callers'

### DIFF
--- a/lib/engine/src/artifact.rs
+++ b/lib/engine/src/artifact.rs
@@ -101,16 +101,6 @@ pub trait Artifact: Send + Sync + Upcastable + MemoryUsage {
         host_state: Box<dyn Any>,
         config: InstanceConfig,
     ) -> Result<InstanceHandle, InstantiationError> {
-        // Validate the CPU features this module was compiled with against the
-        // host CPU features.
-        let host_cpu_features = CpuFeature::for_host();
-        if !host_cpu_features.is_superset(self.cpu_features()) {
-            Err(InstantiationError::CpuFeature(format!(
-                "{:?}",
-                self.cpu_features().difference(host_cpu_features)
-            )))?;
-        }
-
         self.preinstantiate()?;
         let module = self.module();
         let (imports, import_function_envs) = {


### PR DESCRIPTION
For the singlepass compiler the AVX feature is required, but in practice
this is only true when floating point code is used and NaNs need to be
normalized. In `nearcore` we have an option to disable the CPU feature
checks in order to enable testing of simpler contracts on machines that
do not support the AVX feature. Most prominently this is QEMU with some
plugins.

We still check the features at compile time, so that seems to be good
enough for now.

cc @Ekleog @jakmeier 