### PR TITLE
Allow creating symbols map for perf profiler

### DIFF
--- a/lib/api/src/sys/instance.rs
+++ b/lib/api/src/sys/instance.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use std::sync::{Arc, Mutex};
 use thiserror::Error;
 use wasmer_engine::Resolver;
-use wasmer_types::InstanceConfig;
+use wasmer_types::{InstanceConfig, NamedFunction};
 use wasmer_vm::{InstanceHandle, VMContext};
 
 /// A WebAssembly Instance is a stateful, executable
@@ -185,6 +185,11 @@ impl Instance {
     /// Returns the [`Store`] where the `Instance` belongs.
     pub fn store(&self) -> &Store {
         self.module.store()
+    }
+
+    /// Returns list of named functions in instance.
+    pub fn named_functions(&self) -> Vec<NamedFunction> {
+        self.handle.lock().unwrap().named_functions()
     }
 
     #[doc(hidden)]

--- a/lib/compiler/src/function.rs
+++ b/lib/compiler/src/function.rs
@@ -282,7 +282,7 @@ impl Compilation {
         self.debug.clone()
     }
 
-    /// Returns the Trampilines info.
+    /// Returns the Trampolines info.
     pub fn get_trampolines(&self) -> Option<TrampolinesSection> {
         self.trampolines.clone()
     }

--- a/lib/engine-universal/src/artifact.rs
+++ b/lib/engine-universal/src/artifact.rs
@@ -332,6 +332,10 @@ impl Artifact for UniversalArtifact {
         &self.finished_functions
     }
 
+    fn finished_functions_lengths(&self) -> &BoxedSlice<LocalFunctionIndex, usize> {
+        &self.finished_function_lengths
+    }
+
     fn finished_function_call_trampolines(&self) -> &BoxedSlice<SignatureIndex, VMTrampoline> {
         &self.finished_function_call_trampolines
     }

--- a/lib/engine/src/artifact.rs
+++ b/lib/engine/src/artifact.rs
@@ -60,6 +60,9 @@ pub trait Artifact: Send + Sync + Upcastable + MemoryUsage {
     /// ready to be run.
     fn finished_functions(&self) -> &BoxedSlice<LocalFunctionIndex, FunctionBodyPtr>;
 
+    /// Returns the functions code length.
+    fn finished_functions_lengths(&self) -> &BoxedSlice<LocalFunctionIndex, usize>;
+
     /// Returns the function call trampolines allocated in memory of this
     /// `Artifact`, ready to be run.
     fn finished_function_call_trampolines(&self) -> &BoxedSlice<SignatureIndex, VMTrampoline>;
@@ -144,6 +147,7 @@ pub trait Artifact: Send + Sync + Upcastable + MemoryUsage {
             allocator,
             module,
             self.finished_functions().clone(),
+            self.finished_functions_lengths().clone(),
             self.finished_function_call_trampolines().clone(),
             finished_memories,
             finished_tables,

--- a/lib/types/src/lib.rs
+++ b/lib/types/src/lib.rs
@@ -88,7 +88,7 @@ pub use crate::units::{
 pub use crate::values::{Value, WasmValueType};
 pub use types::{
     ExportType, ExternType, FastGasCounter, FunctionType, GlobalInit, GlobalType, ImportType,
-    InstanceConfig, MemoryType, Mutability, TableType, Type, V128,
+    InstanceConfig, MemoryType, Mutability, NamedFunction, TableType, Type, V128,
 };
 
 #[cfg(feature = "enable-rkyv")]

--- a/lib/types/src/types.rs
+++ b/lib/types/src/types.rs
@@ -737,6 +737,17 @@ impl InstanceConfig {
     }
 }
 
+/// Named function information.
+#[derive(Clone, Debug)]
+pub struct NamedFunction {
+    /// Name of the function.
+    pub name: String,
+    /// Address of executable code.
+    pub address: u64,
+    /// Size of executable code.
+    pub size: usize,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/compilers/compilation.rs
+++ b/tests/compilers/compilation.rs
@@ -1,0 +1,100 @@
+use std::sync::Arc;
+use wasmer::*;
+use wasmer_engine::Engine;
+use wasmer_engine_universal::Universal;
+use wasmer_types::Type::I64;
+use wasmer_types::{InstanceConfig, NamedFunction};
+
+fn slow_to_compile_contract(n_fns: usize, n_locals: usize) -> Vec<u8> {
+    let fns = format!("(func (local {}))\n", "i32 ".repeat(n_locals)).repeat(n_fns);
+    let wat = format!(r#"(module {} (func (export "main")))"#, fns);
+    wat2wasm(wat.as_bytes()).unwrap().to_vec()
+}
+
+fn compile_uncached<'a>(
+    store: &'a Store,
+    engine: &'a dyn Engine,
+    code: &'a [u8],
+    time: bool,
+) -> Result<Arc<dyn wasmer_engine::Artifact>, CompileError> {
+    use std::time::Instant;
+    let now = Instant::now();
+    engine.validate(code)?;
+    let validate = now.elapsed().as_millis();
+    let now = Instant::now();
+    let res = engine.compile(code, store.tunables());
+    let compile = now.elapsed().as_millis();
+    if time {
+        println!("validate {}ms compile {}ms", validate, compile);
+    }
+    res
+}
+
+#[test]
+#[ignore]
+fn compilation_test() {
+    let compiler = Singlepass::default();
+    let engine = Universal::new(compiler).engine();
+    let store = Store::new(&engine);
+    for factor in 1..1000 {
+        let code = slow_to_compile_contract(3, 25 * factor);
+        match compile_uncached(&store, &engine, &code, false) {
+            Ok(art) => {
+                let serialized = art.serialize().unwrap();
+                println!(
+                    "{}: artefact is compiled, size is {}",
+                    factor,
+                    serialized.len()
+                );
+            }
+            Err(err) => {
+                println!("err is {:?}", err);
+            }
+        }
+    }
+}
+
+/*
+Code to create perf map.
+
+fn write_perf_profiler_map(functions: &Vec<NamedFunction>) -> Result<(), Box<dyn std::error::Error>>{
+    let pid = process::id();
+    let filename = format!("/tmp/perf-{}.map", pid);
+    let mut file = File::create(filename).expect("Unable to create file");
+    for f in functions {
+        file.write_fmt(format_args!("{:x} {:x} {}\n", f.address, f.size, f.name))?;
+    }
+    Ok(())
+}
+*/
+
+#[test]
+fn profiling() {
+    let wat = r#"
+       (func (export "f1"))
+       (func (export "f2"))
+       (func (export "f3"))
+    "#;
+    let wasm = wat2wasm(wat.as_bytes()).unwrap();
+    let compiler = Singlepass::default();
+    let engine = Universal::new(compiler).engine();
+    let store = Store::new(&engine);
+    match compile_uncached(&store, &engine, &wasm, false) {
+        Ok(art) => unsafe {
+            let serialized = art.serialize().unwrap();
+            let module = wasmer::Module::deserialize(&store, serialized.as_slice()).unwrap();
+            let instance =
+                Instance::new_with_config(&module, InstanceConfig::default(), &imports! {});
+            assert!(instance.is_ok());
+            let instance = instance.unwrap();
+            let named = instance.named_functions();
+            assert_eq!(3, named.len());
+            assert_eq!("f1", named[0].name);
+            assert_eq!("f2", named[1].name);
+            assert_eq!("f3", named[2].name);
+        },
+        Err(_) => {
+            assert!(false)
+        }
+    }
+}

--- a/tests/compilers/fast_gas_metering.rs
+++ b/tests/compilers/fast_gas_metering.rs
@@ -244,7 +244,6 @@ fn test_gas_intrinsic_default() {
 #[test]
 fn test_gas_intrinsic_tricky() {
     let store = get_store();
-    let mut gas_counter = FastGasCounter::new(500, 300000000);
     let module = get_module_tricky_arg(&store);
     static BURNT_GAS: AtomicUsize = AtomicUsize::new(0);
     static HITS: AtomicUsize = AtomicUsize::new(0);

--- a/tests/compilers/main.rs
+++ b/tests/compilers/main.rs
@@ -12,6 +12,7 @@ mod imports;
 mod issues;
 mod middlewares;
 // mod multi_value_imports;
+mod compilation;
 mod native_functions;
 mod serialize;
 mod stack_limiter;

--- a/tests/lib/engine-dummy/src/artifact.rs
+++ b/tests/lib/engine-dummy/src/artifact.rs
@@ -234,6 +234,10 @@ impl Artifact for DummyArtifact {
         &self.finished_functions
     }
 
+    fn finished_functions_lengths(&self) -> &BoxedSlice<LocalFunctionIndex, usize> {
+        unimplemented!();
+    }
+
     fn finished_function_call_trampolines(&self) -> &BoxedSlice<SignatureIndex, VMTrampoline> {
         &self.finished_function_call_trampolines
     }


### PR DESCRIPTION
Adds an option to allow creating instance with dump of symbolic information for use by
perf linux tool.