### PR TITLE
Gas intrinsic optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,10 @@ harness = false
 name = "many_functions"
 harness = false
 
+[[bench]]
+name = "gas_metering"
+harness = false
+
 [[example]]
 name = "early-exit"
 path = "examples/early_exit.rs"

--- a/benches/gas_metering.rs
+++ b/benches/gas_metering.rs
@@ -37,6 +37,10 @@ fn gas(c: &mut Criterion) {
     let cases = [
         ("gas32", 0, "(call $gas (i32.const 0))"),
         ("gas32", 1, "(call $gas (i32.const 1))"),
+        ("gas32", u32::MAX, "(call $gas (i32.const 4294967295))"),
+        ("gas64", 0, "(call $gas64 (i64.const 0))"),
+        ("gas64", 1, "(call $gas64 (i64.const 1))"),
+        ("gas64", u32::MAX, "(call $gas64 (i64.const 4294967295))"),
     ];
     let mut group = c.benchmark_group("gas");
     for (name, size, fee) in cases {
@@ -56,10 +60,10 @@ fn gas(c: &mut Criterion) {
             fee = fee,
         );
         group.bench_with_input(BenchmarkId::new(name, size), &size, |b, _| {
-            let mut gas_counter = wasmer_types::FastGasCounter::new(u64::MAX, 1);
-            let (_, _, instance) = instantiate(wat.as_bytes(), unsafe {
-                InstanceConfig::default().with_counter(std::ptr::addr_of_mut!(gas_counter))
-            });
+            let (_, _, instance) = instantiate(
+                wat.as_bytes(),
+                InstanceConfig::default().with_gas_limit(i64::MAX),
+            );
             let instance = instance.unwrap();
             let main = instance
                 .exports

--- a/benches/gas_metering.rs
+++ b/benches/gas_metering.rs
@@ -1,0 +1,77 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use wasmer::*;
+use wasmer_types::InstanceConfig;
+
+fn instantiate(
+    wasm: &[u8],
+    config: InstanceConfig,
+) -> (Store, Module, Result<Instance, InstantiationError>) {
+    let compiler = Singlepass::default();
+    let store = Store::new(&Universal::new(compiler).engine());
+    let module = Module::new(&store, wasm).unwrap();
+    let gas = Function::new(
+        &store,
+        FunctionType::new(vec![ValType::I32], vec![]),
+        |_| {
+            assert!(false, "gas must always be intrisicified");
+            Ok(vec![])
+        },
+    );
+    let gas64 = Function::new(
+        &store,
+        FunctionType::new(vec![ValType::I64], vec![]),
+        |_| {
+            assert!(false, "gas must always be intrisicified");
+            Ok(vec![])
+        },
+    );
+    let instance = Instance::new_with_config(
+        &module,
+        config,
+        &imports! { "host" => { "gas" => gas, "gas64" => gas64 } },
+    );
+    (store, module, instance)
+}
+
+fn gas(c: &mut Criterion) {
+    let cases = [
+        ("gas32", 0, "(call $gas (i32.const 0))"),
+        ("gas32", 1, "(call $gas (i32.const 1))"),
+    ];
+    let mut group = c.benchmark_group("gas");
+    for (name, size, fee) in cases {
+        let wat = format!(
+            r#"
+            (func $gas (import "host" "gas") (param i32))
+            (func $gas64 (import "host" "gas64") (param i64))
+            (func (export "main") (local i32)
+                loop
+                    {fee}
+                    (i32.add (local.get 0) (i32.const 1))
+                    local.set 0
+                    (br_if 0 (i32.lt_u (local.get 0) (i32.const 10000)))
+                end
+            )
+            "#,
+            fee = fee,
+        );
+        group.bench_with_input(BenchmarkId::new(name, size), &size, |b, _| {
+            let mut gas_counter = wasmer_types::FastGasCounter::new(u64::MAX, 1);
+            let (_, _, instance) = instantiate(wat.as_bytes(), unsafe {
+                InstanceConfig::default().with_counter(std::ptr::addr_of_mut!(gas_counter))
+            });
+            let instance = instance.unwrap();
+            let main = instance
+                .exports
+                .get_function("main")
+                .expect("expected function main");
+            b.iter(|| {
+                main.call(&[]).unwrap();
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, gas);
+criterion_main!(benches);

--- a/lib/api/src/sys/env.rs
+++ b/lib/api/src/sys/env.rs
@@ -7,8 +7,6 @@ use thiserror::Error;
 pub enum HostEnvInitError {
     /// An error occurred when accessing an export
     Export(ExportError),
-    /// Incorrect gas metering config
-    IncorrectGasMeteringConfig,
 }
 
 impl From<ExportError> for HostEnvInitError {

--- a/lib/api/src/sys/instance.rs
+++ b/lib/api/src/sys/instance.rs
@@ -132,14 +132,6 @@ impl Instance {
         config: InstanceConfig,
         resolver: &dyn Resolver,
     ) -> Result<Self, InstantiationError> {
-        unsafe {
-            if (*config.gas_counter).opcode_cost > i32::MAX as u64 {
-                // Fast gas counter logic assumes that individual opcode cost is not too big.
-                return Err(InstantiationError::HostEnvInitialization(
-                    HostEnvInitError::IncorrectGasMeteringConfig,
-                ));
-            }
-        }
         let store = module.store();
         let handle = module.instantiate(resolver, config)?;
         let exports = module
@@ -195,6 +187,11 @@ impl Instance {
     #[doc(hidden)]
     pub fn vmctx_ptr(&self) -> *mut VMContext {
         self.handle.lock().unwrap().vmctx_ptr()
+    }
+
+    /// Return the current remaining gas limit for this function.
+    pub fn gas_limit(&self) -> i64 {
+        self.handle.lock().unwrap().gas_limit()
     }
 }
 

--- a/lib/compiler-singlepass/src/config.rs
+++ b/lib/compiler-singlepass/src/config.rs
@@ -39,11 +39,18 @@ impl Singlepass {
             enable_nan_canonicalization: true,
             enable_stack_check: false,
             middlewares: vec![],
-            intrinsics: vec![Intrinsic {
-                kind: IntrinsicKind::Gas,
-                name: "gas".to_string(),
-                signature: ([Type::I32], []).into(),
-            }],
+            intrinsics: vec![
+                Intrinsic {
+                    kind: IntrinsicKind::Gas,
+                    name: "gas".to_string(),
+                    signature: ([Type::I32], []).into(),
+                },
+                Intrinsic {
+                    kind: IntrinsicKind::Gas,
+                    name: "gas64".to_string(),
+                    signature: ([Type::I64], []).into(),
+                },
+            ],
         }
     }
 
@@ -102,10 +109,10 @@ impl Default for Singlepass {
 impl Intrinsic {
     pub(crate) fn is_params_ok(&self, params: &SmallVec<[Location; 8]>) -> bool {
         match self.kind {
-            IntrinsicKind::Gas => match params[0] {
-                Location::Imm32(value) => value < i32::MAX as u32,
-                _ => false,
-            },
+            IntrinsicKind::Gas => params.len() == 1 && matches!(
+                params[0],
+                Location::Imm32(_) | Location::Imm64(_) | Location::GPR(_)
+            ),
         }
     }
 }

--- a/lib/types/src/lib.rs
+++ b/lib/types/src/lib.rs
@@ -87,7 +87,7 @@ pub use crate::units::{
 };
 pub use crate::values::{Value, WasmValueType};
 pub use types::{
-    ExportType, ExternType, FastGasCounter, FunctionType, GlobalInit, GlobalType, ImportType,
+    ExportType, ExternType, FunctionType, GlobalInit, GlobalType, ImportType,
     InstanceConfig, MemoryType, Mutability, NamedFunction, TableType, Type, V128,
 };
 

--- a/lib/types/src/types.rs
+++ b/lib/types/src/types.rs
@@ -658,25 +658,25 @@ pub struct FastGasCounter {
     /// and the host code.
 
     /// The amount of gas that was irreversibly used for contract execution.
-    pub burnt_gas: u64,
+    pub initial_gas_limit: u64,
     /// Hard gas limit for execution
-    pub gas_limit: u64,
+    pub gas_limit: i64,
     /// Single WASM opcode cost
     pub opcode_cost: u64,
 }
 
 impl FastGasCounter {
     /// New fast gas counter.
-    pub fn new(limit: u64, opcode: u64) -> Self {
+    pub fn new(limit: u64) -> Self {
         FastGasCounter {
-            burnt_gas: 0,
-            gas_limit: limit,
-            opcode_cost: opcode,
+            initial_gas_limit: limit as u64,
+            gas_limit: limit as i64,
+            opcode_cost: 1,
         }
     }
     /// Amount of gas burnt, maybe load as atomic to avoid aliasing issues.
     pub fn burnt(&self) -> u64 {
-        self.burnt_gas
+        self.initial_gas_limit.wrapping_sub(self.gas_limit as u64)
     }
 }
 
@@ -710,8 +710,8 @@ impl InstanceConfig {
     /// Create default instance configuration.
     pub fn default() -> Self {
         let result = Rc::new(UnsafeCell::new(FastGasCounter {
-            burnt_gas: 0,
-            gas_limit: u64::MAX,
+            initial_gas_limit: u64::MAX,
+            gas_limit: i64::MAX,
             opcode_cost: 0,
         }));
         Self {

--- a/lib/vm/src/instance/mod.rs
+++ b/lib/vm/src/instance/mod.rs
@@ -44,7 +44,7 @@ use std::slice;
 use std::sync::Arc;
 use wasmer_types::entity::{packed_option::ReservedValue, BoxedSlice, EntityRef, PrimaryMap};
 use wasmer_types::{
-    DataIndex, DataInitializer, ElemIndex, ExportIndex, FastGasCounter, FunctionIndex, GlobalIndex,
+    DataIndex, DataInitializer, ElemIndex, ExportIndex, FunctionIndex, GlobalIndex,
     GlobalInit, InstanceConfig, LocalFunctionIndex, LocalGlobalIndex, LocalMemoryIndex,
     LocalTableIndex, MemoryIndex, ModuleInfo, NamedFunction, Pages, SignatureIndex, TableIndex,
     TableInitializer,
@@ -407,9 +407,9 @@ impl Instance {
         unsafe { self.vmctx_plus_offset(self.offsets.vmctx_trap_handler()) }
     }
 
-    /// Return a pointer to the gas limiter.
-    pub fn gas_counter_ptr(&self) -> *mut *const FastGasCounter {
-        unsafe { self.vmctx_plus_offset(self.offsets.vmctx_gas_limiter_pointer()) }
+    /// Return a pointer to the gas limit.
+    pub fn gas_limit_ptr(&self) -> *mut i64 {
+        unsafe { self.vmctx_plus_offset(self.offsets.vmctx_gas_limit_begin()) }
     }
 
     /// Return a pointer to initial stack limit.
@@ -1025,7 +1025,7 @@ impl InstanceHandle {
                     vmctx_ptr,
                 );
                 *(instance.trap_catcher_ptr()) = get_trap_handler();
-                *(instance.gas_counter_ptr()) = instance_config.gas_counter;
+                *(instance.gas_limit_ptr()) = instance_config.gas_limit;
                 *(instance.stack_limit_ptr()) = instance_config.stack_limit;
                 *(instance.stack_limit_initial_ptr()) = instance_config.stack_limit;
             }
@@ -1343,6 +1343,13 @@ impl InstanceHandle {
             }
         }
         Ok(())
+    }
+
+    /// Return the current remaining gas limit for this function.
+    pub fn gas_limit(&self) -> i64 {
+        unsafe {
+            *(self.instance.as_ref().gas_limit_ptr())
+        }
     }
 }
 

--- a/lib/vm/src/vmoffsets.rs
+++ b/lib/vm/src/vmoffsets.rs
@@ -469,7 +469,7 @@ impl VMOffsets {
     }
 
     /// The offset of the gas limiter pointer.
-    pub fn vmctx_gas_limiter_pointer(&self) -> u32 {
+    pub fn vmctx_gas_limit_begin(&self) -> u32 {
         self.vmctx_trap_handler_begin()
             .checked_add(if self.has_trap_handlers {
                 u32::from(self.pointer_size)
@@ -481,8 +481,8 @@ impl VMOffsets {
 
     /// The offset of the current stack limit.
     pub fn vmctx_stack_limit_begin(&self) -> u32 {
-        self.vmctx_gas_limiter_pointer()
-            .checked_add(u32::from(self.pointer_size))
+        self.vmctx_gas_limit_begin()
+            .checked_add(8)
             .unwrap()
     }
 

--- a/tests/compilers/fast_gas_metering.rs
+++ b/tests/compilers/fast_gas_metering.rs
@@ -1,296 +1,424 @@
 use std::ptr;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
+use std::sync::Arc;
 use wasmer::*;
 use wasmer_compiler_singlepass::Singlepass;
 use wasmer_engine_universal::Universal;
-use wasmer_types::{FastGasCounter, InstanceConfig};
+use wasmer_types::InstanceConfig;
 
-fn get_module_with_start(store: &Store) -> Module {
-    let wat = r#"
-        (import "host" "func" (func))
-        (import "host" "gas" (func (param i32)))
-        (memory $mem 1)
-        (export "memory" (memory $mem))
-        (export "bar" (func $bar))
-        (func $foo
-            call 0
-            i32.const 126
-            call 1
-            call 0
-            i32.const 300
-            call 1
-            call 0
-        )
-        (func $bar
-            call 0
-            i32.const 300
-            call 1
-        )
-        (start $foo)
-    "#;
-
-    Module::new(&store, &wat).unwrap()
-}
-
-fn get_module(store: &Store) -> Module {
-    let wat = r#"
-        (import "host" "func" (func))
-        (import "host" "has" (func (param i32)))
-        (import "host" "gas" (func (param i32)))
-        (memory $mem 1)
-        (export "memory" (memory $mem))
-        (func (export "foo")
-            call 0
-            i32.const 442
-            call 1
-            i32.const 42
-            call 2
-            call 0
-            i32.const 100
-            call 2
-            call 0
-        )
-        (func (export "bar")
-            call 0
-            i32.const 100
-            call 2
-        )
-        (func (export "zoo")
-            loop
-                i32.const 100
-                call 2
-                br 0
-            end
-        )
-    "#;
-
-    Module::new(&store, &wat).unwrap()
-}
-
-fn get_module_tricky_arg(store: &Store) -> Module {
-    let wat = r#"
-        (import "host" "func" (func))
-        (import "host" "gas" (func (param i32)))
-        (memory $mem 1)
-        (export "memory" (memory $mem))
-        (func $get_gas (param i32) (result i32)
-         i32.const 1
-         get_local 0
-         i32.add)
-        (func (export "foo")
-            i32.const 1000000000
-            call $get_gas
-            call 1
-        )
-        (func (export "zoo")
-            i32.const -2
-            call 1
-        )
-    "#;
-
-    Module::new(&store, &wat).unwrap()
-}
-
-fn get_store() -> Store {
+fn instantiate(
+    hits: Arc<AtomicUsize>,
+    wasm: &[u8],
+    config: InstanceConfig,
+) -> (Store, Module, Result<Instance, InstantiationError>) {
     let compiler = Singlepass::default();
     let store = Store::new(&Universal::new(compiler).engine());
-    store
-}
-
-#[test]
-fn test_gas_intrinsic_in_start() {
-    let store = get_store();
-    let mut gas_counter = FastGasCounter::new(300);
-    let module = get_module_with_start(&store);
-    static HITS: AtomicUsize = AtomicUsize::new(0);
-    let result = Instance::new_with_config(
-        &module,
-        unsafe { InstanceConfig::default().with_counter(ptr::addr_of_mut!(gas_counter)) },
-        &imports! {
-            "host" => {
-                "func" => Function::new(&store, FunctionType::new(vec![], vec![]), |_values| {
-                    HITS.fetch_add(1, SeqCst);
-                    Ok(vec![])
-                }),
-                "gas" => Function::new(&store, FunctionType::new(vec![ValType::I32], vec![]), |_| {
-                    // It shall be never called, as call is intrinsified.
-                    assert!(false);
-                    Ok(vec![])
-                }),
-            },
+    let module = Module::new(&store, wasm).unwrap();
+    let hit = Function::new(&store, FunctionType::new(vec![], vec![]), move |_values| {
+        hits.fetch_add(1, SeqCst);
+        Ok(vec![])
+    });
+    let gas = Function::new(
+        &store,
+        FunctionType::new(vec![ValType::I32], vec![]),
+        |_| {
+            assert!(false, "gas must always be intrisicified");
+            Ok(vec![])
         },
     );
-    assert!(result.is_err());
-    match result {
-        Err(InstantiationError::Start(runtime_error)) => {
-            assert_eq!(runtime_error.message(), "gas limit exceeded")
-        }
-        _ => assert!(false),
-    }
-    // Ensure "func" was called twice.
-    assert_eq!(HITS.swap(0, SeqCst), 2);
-    // Ensure gas was spent.
-    assert_eq!(gas_counter.burnt(), 426);
-    assert_eq!(gas_counter.initial_gas_limit, 300);
-}
-
-#[test]
-fn test_gas_intrinsic_regular() {
-    let store = get_store();
-    let mut gas_counter = FastGasCounter::new(200);
-    let module = get_module(&store);
-    static HITS: AtomicUsize = AtomicUsize::new(0);
+    let gas64 = Function::new(
+        &store,
+        FunctionType::new(vec![ValType::I64], vec![]),
+        |_| {
+            assert!(false, "gas must always be intrisicified");
+            Ok(vec![])
+        },
+    );
     let instance = Instance::new_with_config(
         &module,
-        unsafe { InstanceConfig::default().with_counter(ptr::addr_of_mut!(gas_counter)) },
-        &imports! {
-            "host" => {
-                "func" => Function::new(&store, FunctionType::new(vec![], vec![]), |_values| {
-                    HITS.fetch_add(1, SeqCst);
-                    Ok(vec![])
-                }),
-                "has" => Function::new(&store, FunctionType::new(vec![ValType::I32], vec![]), |_| {
-                    HITS.fetch_add(1, SeqCst);
-                    Ok(vec![])
-                }),
-                "gas" => Function::new(&store, FunctionType::new(vec![ValType::I32], vec![]), |_| {
-                    // It shall be never called, as call is intrinsified.
-                    assert!(false);
-                    Ok(vec![])
-                }),
-            },
-        },
+        config,
+        &imports! { "host" => { "hit" => hit, "gas" => gas, "gas64" => gas64 } },
     );
-    assert!(instance.is_ok());
-    let instance = instance.unwrap();
-    let foo_func = instance
-        .exports
-        .get_function("foo")
-        .expect("expected function foo");
-    let bar_func = instance
-        .exports
-        .get_function("bar")
-        .expect("expected function bar");
-    let zoo_func = instance
-        .exports
-        .get_function("zoo")
-        .expect("expected function zoo");
-    // Ensure "func" was not called.
-    assert_eq!(HITS.load(SeqCst), 0);
-    let e = bar_func.call(&[]);
-    assert!(e.is_ok());
-    // Ensure "func" was called.
-    assert_eq!(HITS.load(SeqCst), 1);
-    assert_eq!(gas_counter.burnt(), 100);
-    let _e = foo_func.call(&[]).err().expect("error calling function");
-    // Ensure "func" and "has" was called again.
-    assert_eq!(HITS.load(SeqCst), 4);
-    assert_eq!(gas_counter.burnt(), 242);
-    // Finally try to exhaust rather large limit.
-    gas_counter.gas_limit += 100_000_000;
-    gas_counter.initial_gas_limit += 100_000_000;
-    let _e = zoo_func.call(&[]).err().expect("error calling function");
-    assert_eq!(gas_counter.burnt(), 100_000_242);
+    (store, module, instance)
 }
 
 #[test]
-fn test_gas_intrinsic_default() {
-    let store = get_store();
-    let module = get_module(&store);
-    static HITS: AtomicUsize = AtomicUsize::new(0);
-    let instance = Instance::new(
-        &module,
-        &imports! {
-            "host" => {
-                "func" => Function::new(&store, FunctionType::new(vec![], vec![]), |_values| {
-                    HITS.fetch_add(1, SeqCst);
-                    Ok(vec![])
-                }),
-                "has" => Function::new(&store, FunctionType::new(vec![ValType::I32], vec![]), |_| {
-                    HITS.fetch_add(1, SeqCst);
-                    Ok(vec![])
-                }),
-                "gas" => Function::new(&store, FunctionType::new(vec![ValType::I32], vec![]), |_| {
-                    // It shall be never called, as call is intrinsified.
-                    assert!(false);
-                    Ok(vec![])
-                }),
-            },
-        },
-    );
-    assert!(instance.is_ok());
-    let instance = instance.unwrap();
-    let foo_func = instance
-        .exports
-        .get_function("foo")
-        .expect("expected function foo");
-    let bar_func = instance
-        .exports
-        .get_function("bar")
-        .expect("expected function bar");
-    // Ensure "func" was called.
-    assert_eq!(HITS.load(SeqCst), 0);
-    let e = bar_func.call(&[]);
-    assert!(e.is_ok());
-    // Ensure "func" was called.
-    assert_eq!(HITS.load(SeqCst), 1);
-    let _e = foo_func.call(&[]);
-    // Ensure "func" and "has" was called.
-    assert_eq!(HITS.load(SeqCst), 5);
+fn test_gas_limiting_in_start() {
+    let test_cases = [
+        (
+            "(call $gas (i32.const 126))",
+            "(call $gas (i32.const 300))",
+            300,
+            2,
+        ),
+        (
+            "(call $gas (i32.const 149))",
+            "(call $gas (i32.const 150))",
+            300,
+            3,
+        ),
+        (
+            "(call $gas (i32.const 0))",
+            "(call $gas (i32.const 150))",
+            300,
+            6,
+        ),
+        (
+            // Verify things work as expeceted when the gas count exceeds i32 maximum.
+            "(call $gas (i32.const 2147483647))", // 2^31-1
+            "(call $gas (i32.const 2147483648))", // 2^31
+            1 << 32,
+            3,
+        ),
+        (
+            // Verify things work as expeceted when the gas count exceeds i32 maximum.
+            "(call $gas64 (i64.const 2147483647))", // 2^31-1
+            "(call $gas64 (i64.const 2147483648))", // 2^31
+            1 << 32,
+            3,
+        ),
+        (
+            // Verify things work as expeceted when the gas count exceeds u32 maximum.
+            "(call $gas64 (i64.const 8589934592))", // 2^33
+            "(call $gas64 (i64.const 8589934592))", // 2^33
+            1 << 34,
+            3,
+        ),
+        (
+            "(call $gas64 (i64.const 9223372036854775807))", // 2^63-1
+            "(call $gas64 (i64.const 0))",
+            i64::MAX,
+            3,
+        ),
+        (
+            // Verify things work as expeceted when the gas count exceeds i64 maximum.
+            "(call $gas64 (i64.const 9223372036854775808))", // 2^63
+            "(call $gas64 (i64.const 0))",
+            i64::MAX,
+            1,
+        ),
+        (
+            // Verify things work as expeceted when the gas count = u64::MAX
+            "(call $gas64 (i64.const 18446744073709551615))", // 2^64 - 1
+            "(call $gas64 (i64.const 0))",
+            i64::MAX,
+            1,
+        ),
+        (
+            // What if the limit is 0?
+            "(call $gas (i32.const 1))",
+            "(call $gas (i32.const 0))",
+            0,
+            1,
+        ),
+        (
+            // Mixed gas
+            "(call $gas (i32.const 1))",
+            "(call $gas64 (i64.const 1))",
+            10,
+            11,
+        ),
+    ];
+    for (idx, (fee1, fee2, gas_limit, expected_hits)) in test_cases.iter().enumerate() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let wat = format!(
+            r#"
+            (import "host" "hit" (func))
+            (func $gas (import "host" "gas") (param i32))
+            (func $gas64 (import "host" "gas64") (param i64))
+            (func $start
+                loop
+                    call 0
+                    {fee1}
+                    call 0
+                    {fee2}
+                    br 0
+                end
+            )
+            (start $start)
+            "#,
+            fee1 = fee1,
+            fee2 = fee2
+        );
+        let (_store, _module, instance) = instantiate(
+            hits.clone(),
+            wat.as_bytes(),
+            InstanceConfig::default().with_gas_limit(*gas_limit),
+        );
+        match instance {
+            Err(InstantiationError::Start(runtime_error)) => {
+                assert_eq!(runtime_error.message(), "gas limit exceeded")
+            }
+            r => assert!(false, "test case {} did not fail due to gas limit: {:?}", idx, r),
+        }
+        // Ensure "func" was called twice.
+        assert_eq!(hits.load(SeqCst), *expected_hits, "test case {} hit count mismatch", idx);
+    }
 }
 
 #[test]
-fn test_gas_intrinsic_tricky() {
-    let store = get_store();
-    let module = get_module_tricky_arg(&store);
-    static BURNT_GAS: AtomicUsize = AtomicUsize::new(0);
-    static HITS: AtomicUsize = AtomicUsize::new(0);
-    let instance = Instance::new(
-        &module,
-        &imports! {
-            "host" => {
-                "func" => Function::new(&store, FunctionType::new(vec![], vec![]), |_values| {
-                    HITS.fetch_add(1, SeqCst);
-                    Ok(vec![])
-                }),
-                "gas" => Function::new(&store, FunctionType::new(vec![ValType::I32], vec![]), |arg| {
-                    // It shall be called, as tricky call is not intrinsified.
-                    HITS.fetch_add(1, SeqCst);
-                    match arg[0] {
-                        Value::I32(arg) => {
-                            BURNT_GAS.fetch_add(arg as usize, SeqCst);
-                        },
-                        _ => {
-                            assert!(false)
-                        }
-                    }
-                    Ok(vec![])
-                }),
-            },
-        },
-    );
-    assert!(instance.is_ok());
-    let instance = instance.unwrap();
-    let foo_func = instance
-        .exports
-        .get_function("foo")
-        .expect("expected function foo");
-
-    let _e = foo_func.call(&[]);
-
-    assert_eq!(BURNT_GAS.load(SeqCst), 1000000001);
-    // Ensure "gas" was called.
-    assert_eq!(HITS.load(SeqCst), 1);
-
-    let zoo_func = instance
-        .exports
-        .get_function("zoo")
-        .expect("expected function zoo");
-
-    let _e = zoo_func.call(&[]);
-    // We decremented gas by two.
-    assert_eq!(BURNT_GAS.load(SeqCst), 999999999);
-    // Ensure "gas" was called.
-    assert_eq!(HITS.load(SeqCst), 2);
+fn test_remaining_gas() {
+    let test_cases = [
+        ("(call $gas (i32.const 100))", 100, 0, true),
+        ("(call $gas (i32.const 0))", 100, 100, true),
+        ("(call $gas (i32.const 50)) (call $gas64 (i64.const 50))", 100, 0, true),
+    ];
+    for (idx, (fees, gas_limit, expected_remaining, success)) in test_cases.iter().enumerate() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let wat = format!(
+            r#"
+            (func $gas (import "host" "gas") (param i32))
+            (func $gas64 (import "host" "gas64") (param i64))
+            (func (export "main")
+                {fees}
+            )
+            "#,
+            fees = fees,
+        );
+        let (_store, _module, instance) = instantiate(
+            hits.clone(),
+            wat.as_bytes(),
+            InstanceConfig::default().with_gas_limit(*gas_limit),
+        );
+        let instance = instance.unwrap();
+        let main = instance
+            .exports
+            .get_function("main")
+            .expect("expected function main");
+        match main.call(&[]) {
+            Err(runtime_error) if !success => {
+                assert_eq!(runtime_error.message(), "gas limit exceeded")
+            }
+            Ok(_) if *success => {}
+            r => assert!(false, "test case {} produce correct result: {:?}", idx, r),
+        }
+        assert_eq!(
+            instance.gas_limit(), *expected_remaining,
+            "test case {} remaining gas limit is wrong", idx);
+    }
 }
+
+// #[test]
+// fn test_gas_intrinsic_tricky() {
+//     let store = get_store();
+//     let module = get_module_tricky_arg(&store);
+//     static BURNT_GAS: AtomicUsize = AtomicUsize::new(0);
+//     static HITS: AtomicUsize = AtomicUsize::new(0);
+//     let instance = Instance::new(
+//         &module,
+//         &imports! {
+//             "host" => {
+//                 "func" => Function::new(&store, FunctionType::new(vec![], vec![]), |_values| {
+//                     HITS.fetch_add(1, SeqCst);
+//                     Ok(vec![])
+//                 }),
+//                 "gas" => Function::new(&store, FunctionType::new(vec![ValType::I32], vec![]), |arg| {
+//                     // It shall be called, as tricky call is not intrinsified.
+//                     HITS.fetch_add(1, SeqCst);
+//                     match arg[0] {
+//                         Value::I32(arg) => {
+//                             BURNT_GAS.fetch_add(arg as usize, SeqCst);
+//                         },
+//                         _ => {
+//                             assert!(false)
+//                         }
+//                     }
+//                     Ok(vec![])
+//                 }),
+//             },
+//         },
+//     );
+//     assert!(instance.is_ok());
+//     let instance = instance.unwrap();
+//     let foo_func = instance
+//         .exports
+//         .get_function("foo")
+//         .expect("expected function foo");
+//
+//     let _e = foo_func.call(&[]);
+//
+//     assert_eq!(BURNT_GAS.load(SeqCst), 1000000001);
+//     // Ensure "gas" was called.
+//     assert_eq!(HITS.load(SeqCst), 1);
+//
+//     let zoo_func = instance
+//         .exports
+//         .get_function("zoo")
+//         .expect("expected function zoo");
+//
+//     let _e = zoo_func.call(&[]);
+//     // We decremented gas by two.
+//     assert_eq!(BURNT_GAS.load(SeqCst), 999999999);
+//     // Ensure "gas" was called.
+//     assert_eq!(HITS.load(SeqCst), 2);
+// }
+
+// #[test]
+// fn test_gas_intrinsic_regular() {
+//     let store = get_store();
+//     let mut gas_counter = FastGasCounter::new(200);
+//     let module = get_module(&store);
+//     static HITS: AtomicUsize = AtomicUsize::new(0);
+//     let instance = Instance::new_with_config(
+//         &module,
+//         unsafe { InstanceConfig::default().with_counter(ptr::addr_of_mut!(gas_counter)) },
+//         &imports! {
+//             "host" => {
+//                 "func" => Function::new(&store, FunctionType::new(vec![], vec![]), |_values| {
+//                     HITS.fetch_add(1, SeqCst);
+//                     Ok(vec![])
+//                 }),
+//                 "has" => Function::new(&store, FunctionType::new(vec![ValType::I32], vec![]), |_| {
+//                     HITS.fetch_add(1, SeqCst);
+//                     Ok(vec![])
+//                 }),
+//                 "gas" => Function::new(&store, FunctionType::new(vec![ValType::I32], vec![]), |_| {
+//                     // It shall be never called, as call is intrinsified.
+//                     assert!(false);
+//                     Ok(vec![])
+//                 }),
+//             },
+//         },
+//     );
+//     assert!(instance.is_ok());
+//     let instance = instance.unwrap();
+//     let foo_func = instance
+//         .exports
+//         .get_function("foo")
+//         .expect("expected function foo");
+//     let bar_func = instance
+//         .exports
+//         .get_function("bar")
+//         .expect("expected function bar");
+//     let zoo_func = instance
+//         .exports
+//         .get_function("zoo")
+//         .expect("expected function zoo");
+//     // Ensure "func" was not called.
+//     assert_eq!(HITS.load(SeqCst), 0);
+//     let e = bar_func.call(&[]);
+//     assert!(e.is_ok());
+//     // Ensure "func" was called.
+//     assert_eq!(HITS.load(SeqCst), 1);
+//     assert_eq!(gas_counter.burnt(), 100);
+//     let _e = foo_func.call(&[]).err().expect("error calling function");
+//     // Ensure "func" and "has" was called again.
+//     assert_eq!(HITS.load(SeqCst), 4);
+//     assert_eq!(gas_counter.burnt(), 242);
+//     // Finally try to exhaust rather large limit.
+//     gas_counter.gas_limit += 100_000_000;
+//     gas_counter.initial_gas_limit += 100_000_000;
+//     let _e = zoo_func.call(&[]).err().expect("error calling function");
+//     assert_eq!(gas_counter.burnt(), 100_000_242);
+// }
+
+// #[test]
+// fn test_gas_intrinsic_default() {
+//     let store = get_store();
+//     let module = get_module(&store);
+//     static HITS: AtomicUsize = AtomicUsize::new(0);
+//     let instance = Instance::new(
+//         &module,
+//         &imports! {
+//             "host" => {
+//                 "func" => Function::new(&store, FunctionType::new(vec![], vec![]), |_values| {
+//                     HITS.fetch_add(1, SeqCst);
+//                     Ok(vec![])
+//                 }),
+//                 "has" => Function::new(&store, FunctionType::new(vec![ValType::I32], vec![]), |_| {
+//                     HITS.fetch_add(1, SeqCst);
+//                     Ok(vec![])
+//                 }),
+//                 "gas" => Function::new(&store, FunctionType::new(vec![ValType::I32], vec![]), |_| {
+//                     // It shall be never called, as call is intrinsified.
+//                     assert!(false);
+//                     Ok(vec![])
+//                 }),
+//             },
+//         },
+//     );
+//     assert!(instance.is_ok());
+//     let instance = instance.unwrap();
+//     let foo_func = instance
+//         .exports
+//         .get_function("foo")
+//         .expect("expected function foo");
+//     let bar_func = instance
+//         .exports
+//         .get_function("bar")
+//         .expect("expected function bar");
+//     // Ensure "func" was called.
+//     assert_eq!(HITS.load(SeqCst), 0);
+//     let e = bar_func.call(&[]);
+//     assert!(e.is_ok());
+//     // Ensure "func" was called.
+//     assert_eq!(HITS.load(SeqCst), 1);
+//     let _e = foo_func.call(&[]);
+//     // Ensure "func" and "has" was called.
+//     assert_eq!(HITS.load(SeqCst), 5);
+// }
+
+
+
+
+
+
+// fn get_module(store: &Store) -> Module {
+//     let wat = r#"
+//         (import "host" "func" (func))
+//         (import "host" "has" (func (param i32)))
+//         (import "host" "gas" (func (param i32)))
+//         (memory $mem 1)
+//         (export "memory" (memory $mem))
+//         (func (export "foo")
+//             call 0
+//             i32.const 442
+//             call 1
+//             i32.const 42
+//             call 2
+//             call 0
+//             i32.const 100
+//             call 2
+//             call 0
+//         )
+//         (func (export "bar")
+//             call 0
+//             i32.const 100
+//             call 2
+//         )
+//         (func (export "zoo")
+//             loop
+//                 i32.const 100
+//                 call 2
+//                 br 0
+//             end
+//         )
+//     "#;
+//
+//     Module::new(&store, &wat).unwrap()
+// }
+
+// fn get_module_tricky_arg(store: &Store) -> Module {
+//     let wat = r#"
+//         (import "host" "func" (func))
+//         (import "host" "gas" (func (param i32)))
+//         (memory $mem 1)
+//         (export "memory" (memory $mem))
+//         (func $get_gas (param i32) (result i32)
+//          i32.const 1
+//          get_local 0
+//          i32.add)
+//         (func (export "foo")
+//             i32.const 1000000000
+//             call $get_gas
+//             call 1
+//         )
+//         (func (export "zoo")
+//             i32.const -2
+//             call 1
+//         )
+//     "#;
+//
+//     Module::new(&store, &wat).unwrap()
+// }

--- a/tests/compilers/stack_limiter.rs
+++ b/tests/compilers/stack_limiter.rs
@@ -35,7 +35,7 @@ fn stack_limit_hit() {
     let module = Module::new(&store, &wasm).unwrap();
     let instance = Instance::new_with_config(
         &module,
-        unsafe { InstanceConfig::default().with_stack_limit(100000) },
+        InstanceConfig::default().with_stack_limit(100000),
         &imports! {},
     );
     assert!(instance.is_ok());
@@ -82,7 +82,7 @@ fn stack_limit_operand_stack() {
     let module = Module::new(&store, &wat).unwrap();
     let instance = Instance::new_with_config(
         &module,
-        unsafe { InstanceConfig::default().with_stack_limit(1000) },
+        InstanceConfig::default().with_stack_limit(1000),
         &imports! {},
     );
     assert!(instance.is_ok());
@@ -134,7 +134,7 @@ fn stack_limit_ok() {
     let module = Module::new(&store, &wat).unwrap();
     let instance = Instance::new_with_config(
         &module,
-        unsafe { InstanceConfig::default().with_stack_limit(1000) },
+        InstanceConfig::default().with_stack_limit(1000),
         &imports! {},
     );
     assert!(instance.is_ok());
@@ -154,7 +154,7 @@ fn stack_limit_huge_limit() {
     let module = Module::new(&store, &wat).unwrap();
     let instance = Instance::new_with_config(
         &module,
-        unsafe { InstanceConfig::default().with_stack_limit(0x7FFF_FFFF) },
+        InstanceConfig::default().with_stack_limit(0x7FFF_FFFF),
         &imports! {},
     );
     assert!(instance.is_ok());
@@ -181,7 +181,7 @@ fn stack_limit_no_args() {
     let module = Module::new(&store, &wat).unwrap();
     let instance = Instance::new_with_config(
         &module,
-        unsafe { InstanceConfig::default().with_stack_limit(1000) },
+        InstanceConfig::default().with_stack_limit(1000),
         &imports! {},
     );
     assert!(instance.is_ok());


### PR DESCRIPTION
This is a WIP snapshot of the work that went into the gas intrinsic optimization on wasmer side of things. This work is closely related to https://github.com/near/nearcore/pull/6066.

The implementation here is incomplete as we've found the improvement to be not as significant as we had hoped. I'm suspending the work on this for the time being, but IME the improvements may be significant enough to consider coming back to this later.

In particular this PR adds a criterion benchmark which stresses the gas codegen. The following image presents some of the wall-clock time results (red is current, blue is new implementation; some other measurements are available in the referenced nearcore PR):

![Criterion comparison](https://user-images.githubusercontent.com/679122/151581173-2c0740f8-0f59-4e08-ade2-97721a9d8449.png)