### PR TITLE
reproducible spill order for registers on call

### DIFF
--- a/lib/compiler-singlepass/src/machine.rs
+++ b/lib/compiler-singlepass/src/machine.rs
@@ -38,11 +38,15 @@ impl Machine {
     }
 
     pub fn get_used_gprs(&self) -> Vec<GPR> {
-        self.used_gprs.iter().cloned().collect()
+        let mut result = self.used_gprs.iter().cloned().collect::<Vec<_>>();
+        result.sort_unstable();
+        result
     }
 
     pub fn get_used_xmms(&self) -> Vec<XMM> {
-        self.used_xmms.iter().cloned().collect()
+        let mut result = self.used_xmms.iter().cloned().collect::<Vec<_>>();
+        result.sort_unstable();
+        result
     }
 
     pub fn get_vmctx_reg() -> GPR {


### PR DESCRIPTION
Before a call `wasmer` will spill `used_gprs` and `used_xmms`. However
they are stored in a `HashSet` and therefore the registers will not be
returned in any particular order. This can then result in run-to-run
variation in spill/restore order and thus non-reproducible artifacts.