### PR TITLE
convention-over-configuration test setup

### DIFF
--- a/lib/types/Cargo.toml
+++ b/lib/types/Cargo.toml
@@ -29,5 +29,4 @@ core = []
 
 [[test]]
 name = "partial-sum-map"
-path = "tests/partial-sum-map/test_target.rs"
 harness = false

--- a/lib/types/tests/partial-sum-map/main.rs
+++ b/lib/types/tests/partial-sum-map/main.rs
@@ -1,8 +1,7 @@
-use bolero::check;
 use wasmer_types::partial_sum_map::{Error, PartialSumMap};
 
 fn main() {
-    check!()
+    bolero::check!()
         .with_type::<(Vec<(u32, u32)>, Vec<u32>)>()
         .for_each(|input| {
             let adds = &input.0;


### PR DESCRIPTION
No need to specify path to directory if the entry is named `main.rs`