### PR TITLE
precompute offsets ahead-of-time rather than on each dereference

### DIFF
--- a/lib/vm/src/instance/allocator.rs
+++ b/lib/vm/src/instance/allocator.rs
@@ -129,7 +129,7 @@ impl InstanceAllocator {
     ///   memory, i.e. `Self.instance_ptr` must have been allocated by
     ///   `Self::new`.
     unsafe fn memory_definition_locations(&self) -> Vec<NonNull<VMMemoryDefinition>> {
-        let num_memories = self.offsets.num_local_memories;
+        let num_memories = self.offsets.num_local_memories();
         let num_memories = usize::try_from(num_memories).unwrap();
         let mut out = Vec::with_capacity(num_memories);
 
@@ -163,7 +163,7 @@ impl InstanceAllocator {
     ///   memory, i.e. `Self.instance_ptr` must have been allocated by
     ///   `Self::new`.
     unsafe fn table_definition_locations(&self) -> Vec<NonNull<VMTableDefinition>> {
-        let num_tables = self.offsets.num_local_tables;
+        let num_tables = self.offsets.num_local_tables();
         let num_tables = usize::try_from(num_tables).unwrap();
         let mut out = Vec::with_capacity(num_tables);
 


### PR DESCRIPTION
Criterion results on a test related to near/nearcore-private-1#2:
```
compile                 time:   [9.7873 ms 9.8477 ms 9.9119 ms]
                        change: [-5.2388% -4.2981% -3.2369%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Manual testing on the exact test of near/nearcore-private-1#2 confirms the ~5% speedup:

Non-rayon goes down to 24.5-25ms from 25.5-26ms
Rayon goes down to 12ms from 12.5ms

This also feels more like a code cleanup than added complexity for optimization’s sake to me, but I would understand if other people thought the added invariants are added complexity