### PR TITLE
implement lzcnt and tzcnt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1697,6 +1697,7 @@ dependencies = [
  "byteorder",
  "dynasm",
  "dynasmrt",
+ "enumset",
  "hashbrown 0.11.2",
  "lazy_static",
  "memoffset",

--- a/lib/compiler-singlepass/Cargo.toml
+++ b/lib/compiler-singlepass/Cargo.toml
@@ -18,15 +18,16 @@ name = "wasmer_compiler_singlepass"
 wasmer-compiler = { path = "../compiler", package = "wasmer-compiler-near", version = "=2.4.0", features = ["translator"], default-features = false }
 wasmer-vm = { path = "../vm", package = "wasmer-vm-near", version = "=2.4.0" }
 wasmer-types = { path = "../types", package = "wasmer-types-near", version = "=2.4.0", default-features = false, features = ["std"] }
-rayon = { version = "1.5", optional = true }
-hashbrown = { version = "0.11", optional = true }
-more-asserts = "0.2"
+byteorder = "1.3"
 dynasm = "1.0"
 dynasmrt = "1.0"
+enumset = "1.0"
+hashbrown = { version = "0.11", optional = true }
 lazy_static = "1.4"
-byteorder = "1.3"
-smallvec = "1.6"
 memoffset = "0.6"
+more-asserts = "0.2"
+rayon = { version = "1.5", optional = true }
+smallvec = "1.6"
 tracing = "0.1"
 
 [dev-dependencies]

--- a/lib/compiler-singlepass/src/codegen_x64.rs
+++ b/lib/compiler-singlepass/src/codegen_x64.rs
@@ -13,7 +13,7 @@ use wasmer_compiler::{
     CallingConvention, CompiledFunction, CompiledFunctionFrameInfo, CustomSection,
     CustomSectionProtection, FunctionBody, FunctionBodyData, InstructionAddressMap,
     ModuleTranslationState, Relocation, RelocationKind, RelocationTarget, SectionBody,
-    SectionIndex, SourceLoc,
+    SectionIndex, SourceLoc, Target,
 };
 use wasmer_types::{
     entity::{EntityRef, PrimaryMap, SecondaryMap},
@@ -38,6 +38,9 @@ pub(crate) struct FuncGen<'a> {
 
     /// ModuleInfo compilation config.
     config: &'a Singlepass,
+
+    /// Target to which we compile
+    target: &'a Target,
 
     /// Offsets of vmctx fields.
     vmoffsets: &'a VMOffsets,
@@ -1900,6 +1903,7 @@ impl<'a> FuncGen<'a> {
         module: &'a ModuleInfo,
         module_translation_state: &'a ModuleTranslationState,
         config: &'a Singlepass,
+        target: &'a Target,
         vmoffsets: &'a VMOffsets,
         _table_styles: &'a PrimaryMap<TableIndex, TableStyle>,
         local_func_index: LocalFunctionIndex,
@@ -1926,6 +1930,7 @@ impl<'a> FuncGen<'a> {
             module,
             module_translation_state,
             config,
+            target,
             vmoffsets,
             local_types: wasmer_types::partial_sum_map::PartialSumMap::new(),
             assembler,
@@ -2321,7 +2326,7 @@ impl<'a> FuncGen<'a> {
                     }
                 };
 
-                if self.assembler.arch_has_xzcnt() {
+                if self.assembler.arch_has_xzcnt(self.target.cpu_features()) {
                     self.assembler.arch_emit_lzcnt(
                         Size::S32,
                         Location::GPR(src),
@@ -2386,7 +2391,7 @@ impl<'a> FuncGen<'a> {
                     }
                 };
 
-                if self.assembler.arch_has_xzcnt() {
+                if self.assembler.arch_has_xzcnt(self.target.cpu_features()) {
                     self.assembler.arch_emit_tzcnt(
                         Size::S32,
                         Location::GPR(src),
@@ -2552,7 +2557,7 @@ impl<'a> FuncGen<'a> {
                     }
                 };
 
-                if self.assembler.arch_has_xzcnt() {
+                if self.assembler.arch_has_xzcnt(self.target.cpu_features()) {
                     self.assembler.arch_emit_lzcnt(
                         Size::S64,
                         Location::GPR(src),
@@ -2617,7 +2622,7 @@ impl<'a> FuncGen<'a> {
                     }
                 };
 
-                if self.assembler.arch_has_xzcnt() {
+                if self.assembler.arch_has_xzcnt(self.target.cpu_features()) {
                     self.assembler.arch_emit_tzcnt(
                         Size::S64,
                         Location::GPR(src),

--- a/lib/compiler-singlepass/src/compiler.rs
+++ b/lib/compiler-singlepass/src/compiler.rs
@@ -117,6 +117,7 @@ impl Compiler for SinglepassCompiler {
                         module,
                         module_translation,
                         &self.config,
+                        &target,
                         &vmoffsets,
                         &table_styles,
                         i,

--- a/lib/compiler-singlepass/src/emitter_x64.rs
+++ b/lib/compiler-singlepass/src/emitter_x64.rs
@@ -1419,6 +1419,27 @@ impl Emitter for Assembler {
         self.emit_jmp_location(Location::GPR(target));
     }
 
+    fn arch_has_xzcnt(&self) -> bool {
+        std::is_x86_feature_detected!("bmi1") // tzcnt
+            && std::is_x86_feature_detected!("lzcnt")
+    }
+
+    fn arch_emit_lzcnt(&mut self, sz: Size, src: Location, dst: Location) {
+        binop_gpr_gpr!(lzcnt, self, sz, src, dst, {
+            binop_mem_gpr!(lzcnt, self, sz, src, dst, {
+                panic!("singlepass can't emit LZCNT {:?} {:?} {:?}", sz, src, dst)
+            })
+        })
+    }
+
+    fn arch_emit_tzcnt(&mut self, sz: Size, src: Location, dst: Location) {
+        binop_gpr_gpr!(tzcnt, self, sz, src, dst, {
+            binop_mem_gpr!(tzcnt, self, sz, src, dst, {
+                panic!("singlepass can't emit TZCNT {:?} {:?} {:?}", sz, src, dst)
+            })
+        })
+    }
+
     fn arch_mov64_imm_offset(&self) -> usize {
         2
     }


### PR DESCRIPTION
Performance changes are:
- For i64.clz, compile-time gets 40% faster and runtime gets 5x faster
- For i64.ctz, compile-time gets 35-40% faster and runtime gets 5-6x faster

(The difference between results probably comes from variance in measurement)

We should add BMI1 and LZCNT to at least our recommended feature list on https://near-nodes.io/validator/hardware ; and probably our required feature list.