### PR TITLE
do not clone FunctionType contents but just the Arc's

### DIFF
--- a/lib/api/src/sys/externals/function.rs
+++ b/lib/api/src/sys/externals/function.rs
@@ -275,7 +275,7 @@ impl Function {
         let signature = store
             .engine()
             // TODO(0-copy):
-            .register_signature((&ty).into());
+            .register_signature(ty);
 
         Self {
             store: store.clone(),
@@ -328,7 +328,7 @@ impl Function {
         let signature = store
             .engine()
             // TODO(0-copy):
-            .register_signature((&function.ty()).into());
+            .register_signature(function.ty());
 
         Self {
             store: store.clone(),
@@ -389,7 +389,7 @@ impl Function {
             build_export_function_metadata::<Env>(env, Env::init_with_instance);
 
         let vmctx = VMFunctionEnvironment { host_env };
-        let signature = store.engine().register_signature((&function.ty()).into());
+        let signature = store.engine().register_signature(function.ty());
         Self {
             store: store.clone(),
             exported: ExportFunction {

--- a/lib/engine-universal/src/engine.rs
+++ b/lib/engine-universal/src/engine.rs
@@ -211,7 +211,7 @@ impl UniversalEngine {
         let signatures = module
             .signatures
             .iter()
-            .map(|(_, sig)| inner_engine.signatures.register(sig.into()))
+            .map(|(_, sig)| inner_engine.signatures.register(sig.clone()))
             .collect::<PrimaryMap<SignatureIndex, _>>()
             .into_boxed_slice();
         let (functions, trampolines, dynamic_trampolines, custom_sections) = inner_engine
@@ -352,7 +352,12 @@ impl UniversalEngine {
         let signatures = module
             .signatures
             .values()
-            .map(|sig| inner_engine.signatures.register(sig.into()))
+            .map(|sig| {
+                let sig_ref = FunctionTypeRef::from(sig);
+                inner_engine
+                    .signatures
+                    .register(FunctionType::new(sig_ref.params(), sig_ref.results()))
+            })
             .collect::<PrimaryMap<SignatureIndex, _>>()
             .into_boxed_slice();
         let (functions, trampolines, dynamic_trampolines, custom_sections) = inner_engine
@@ -454,7 +459,7 @@ impl Engine for UniversalEngine {
     }
 
     /// Register a signature
-    fn register_signature(&self, func_type: FunctionTypeRef<'_>) -> VMSharedSignatureIndex {
+    fn register_signature(&self, func_type: FunctionType) -> VMSharedSignatureIndex {
         self.inner().signatures.register(func_type)
     }
 

--- a/lib/engine/src/engine.rs
+++ b/lib/engine/src/engine.rs
@@ -3,7 +3,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 use std::sync::Arc;
 use wasmer_compiler::{CompileError, Target};
-use wasmer_types::{FunctionType, FunctionTypeRef};
+use wasmer_types::FunctionType;
 use wasmer_vm::{Artifact, Tunables, VMCallerCheckedAnyfunc, VMFuncRef, VMSharedSignatureIndex};
 
 mod private {
@@ -21,7 +21,7 @@ pub trait Engine {
     fn target(&self) -> &Target;
 
     /// Register a signature
-    fn register_signature(&self, func_type: FunctionTypeRef<'_>) -> VMSharedSignatureIndex;
+    fn register_signature(&self, func_type: FunctionType) -> VMSharedSignatureIndex;
 
     /// Register a function's data.
     fn register_function_metadata(&self, func_data: VMCallerCheckedAnyfunc) -> VMFuncRef;

--- a/lib/vm/src/sig_registry.rs
+++ b/lib/vm/src/sig_registry.rs
@@ -6,7 +6,7 @@
 
 use std::collections::{hash_map, HashMap};
 use std::convert::TryFrom;
-use wasmer_types::{FunctionType, FunctionTypeRef};
+use wasmer_types::FunctionType;
 
 /// An index into the shared signature registry, usable for checking signatures
 /// at indirect calls.
@@ -41,16 +41,15 @@ impl SignatureRegistry {
     }
 
     /// Register a signature and return its unique index.
-    pub fn register(&mut self, sig: FunctionTypeRef<'_>) -> VMSharedSignatureIndex {
+    pub fn register(&mut self, sig: FunctionType) -> VMSharedSignatureIndex {
         let len = self.index_to_data.len();
-        // TODO(0-copy): this. should. not. allocate.
+        // TODO(0-copy): this. should. not. allocate. (and take FunctionTypeRef as a parameter)
         //
         // This is pretty hard to avoid, however. In order to implement bijective map, we'd want
         // a `Rc<FunctionType>`, but indexing into a map keyed by `Rc<FunctionType>` with
         // `FunctionTypeRef` is… not possible given the current API either.
         //
         // Consider `transmute` or `hashbrown`'s raw_entry.
-        let sig = FunctionType::new(sig.params(), sig.results());
         match self.type_to_index.entry(sig.clone()) {
             hash_map::Entry::Occupied(entry) => *entry.get(),
             hash_map::Entry::Vacant(entry) => {


### PR DESCRIPTION
This improves performance of post-compile-loading the reproducer from near/nearcore-private#4 by ~10%